### PR TITLE
fix(explore): Remove query autotrigger

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.tsx
@@ -505,6 +505,7 @@ export const tooltipTemplate = {
   config: {
     type: TooltipTemplateControl,
     label: t('Customize tooltips template'),
+    renderTrigger: true,
     debounceDelay: 30,
     default: '',
     description: '',

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -371,15 +371,6 @@ function ExploreViewContainer(props) {
     props.form_data,
   ]);
 
-  // Simple debounced auto-query for non-renderTrigger controls
-  const debouncedAutoQuery = useMemo(
-    () =>
-      debounce(() => {
-        onQuery();
-      }, 1000), // 1 second delay
-    [onQuery],
-  );
-
   const handleKeydown = useCallback(
     event => {
       const controlOrCommand = event.ctrlKey || event.metaKey;
@@ -573,25 +564,8 @@ function ExploreViewContainer(props) {
       if (displayControlsChanged.length > 0) {
         reRenderChart(displayControlsChanged);
       }
-
-      // Auto-update for non-renderTrigger controls
-      const queryControlsChanged = changedControlKeys.filter(
-        key =>
-          !props.controls[key].renderTrigger &&
-          !props.controls[key].dontRefreshOnChange,
-      );
-      if (queryControlsChanged.length > 0) {
-        // Check if there are no validation errors before auto-updating
-        const hasErrors = Object.values(props.controls).some(
-          control =>
-            control.validationErrors && control.validationErrors.length > 0,
-        );
-        if (!hasErrors) {
-          debouncedAutoQuery();
-        }
-      }
     }
-  }, [props.controls, props.ownState, debouncedAutoQuery]);
+  }, [props.controls, props.ownState]);
 
   const chartIsStale = useMemo(() => {
     if (lastQueriedControls) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR removes auto-triggering of queries in the explore view and enhances tooltip configuration in deck.gl. The ExploreViewContainer no longer uses debounced auto-query based on control changes, and a new property clarifies when controls should render tooltips, resulting in more reliable query processing and predictable UI behavior.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>